### PR TITLE
Standardize verified TTL to match the window config

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,13 +125,12 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 	}
 
 	bc := CaptchaProtect{
-		next:      next,
-		name:      name,
-		config:    config,
-		rateCache: lru.New(expiration, 1*time.Minute),
-		botCache:  lru.New(expiration, 1*time.Minute),
-		// allow good IPs to pass through for ten days
-		verifiedCache: lru.New(240*time.Hour, 1*time.Hour),
+		next:          next,
+		name:          name,
+		config:        config,
+		rateCache:     lru.New(expiration, 1*time.Minute),
+		botCache:      lru.New(expiration, 1*time.Hour),
+		verifiedCache: lru.New(expiration, 1*time.Hour),
 		exemptIps:     ips,
 	}
 


### PR DESCRIPTION
I thought ten days for the verification cache ttl would be good so we wouldn't bother legit clients. But need some better data around this to make a deviation like that from the bot and rate limit cache ttl. Reason being, this is sort of confusing and not documented at all.

Instead let's just set the verification cache as the same ttl the rate/bots have. More than likely if a verification happened it's because the rate limit was exceeded in the client subnet, and after the ttl expires the rate limit may no longer be set, so the client may not even get challenged again if they happen to visit say 2d later.