### PR TITLE
[minor] revert v2.0.0 to v1.14.0

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -23,6 +23,12 @@ jobs:
       - name: check YML
         run: yq . .traefik.yml
 
+      - name: check Traefik module path
+        run: |
+          module_path="$(go list -m)"
+          test "$module_path" = "github.com/libops/captcha-protect"
+          test "$(yq '.import' .traefik.yml)" = "$module_path"
+
       - name: go mod tidy
         run: |
           go mod tidy

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Captcha Protect
 
 [![lint-test](https://github.com/libops/captcha-protect/actions/workflows/lint-test.yml/badge.svg)](https://github.com/libops/captcha-protect/actions/workflows/lint-test.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/libops/captcha-protect)](https://goreportcard.com/report/github.com/libops/captcha-protect)
 [![codecov](https://codecov.io/gh/libops/captcha-protect/branch/main/graph/badge.svg)](https://codecov.io/gh/libops/captcha-protect)
 
 Captcha Protect is a Traefik middleware that challenges client IPs on protected routes. It can use Turnstile, reCAPTCHA, hCaptcha, or proof-of-javascript for the challenge.

--- a/ci/test.go
+++ b/ci/test.go
@@ -131,6 +131,7 @@ func traefikPluginLogFailure(output string) (string, bool) {
 		"Plugins are disabled",
 		"failed to create Yaegi interpreter",
 		"failed to import plugin code",
+		"failed to eval New",
 		"cannot use type",
 		"cannot define new methods",
 	}

--- a/ci/test_test.go
+++ b/ci/test_test.go
@@ -14,6 +14,18 @@ func TestTraefikPluginLogFailureDetectsYaegiImportErrors(t *testing.T) {
 	}
 }
 
+func TestTraefikPluginLogFailureDetectsEvalErrors(t *testing.T) {
+	logs := `traefik-1  | {"level":"error","plugins":["captcha-protect"],"error":"failed to eval New: 1:28: undefined: v2","message":"Plugins are disabled because an error has occurred."}`
+
+	failure, found := traefikPluginLogFailure(logs)
+	if !found {
+		t.Fatal("expected Traefik plugin eval failure to be detected")
+	}
+	if failure != "Plugins are disabled" {
+		t.Fatalf("expected first detected failure %q, got %q", "Plugins are disabled", failure)
+	}
+}
+
 func TestTraefikPluginLogFailureAllowsCleanLogs(t *testing.T) {
 	logs := `traefik-1  | {"level":"info","message":"Configuration loaded from flags."}`
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+// Traefik's plugin service cannot resolve major-version module suffixes for
+// plugins with vendored dependencies. Keep this module on the v1 path.
 module github.com/libops/captcha-protect
 
 go 1.25.0


### PR DESCRIPTION
Closes https://github.com/libops/captcha-protect/issues/104